### PR TITLE
Eliminación del formulario de registro del código de asistencia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
+### [1.7.1] - 2026-06-08
+
+### ❌ Eliminado
+
+- Se quitó la opción de "Marcar Asistencia" en el módulo `cit_citas`. Ya no era funcional, ahora se utiliza un código de barras. Genera confusión a los usuarios, que intentan escribir el código de barras en este campo, lo cual les marca un error.
+
+
 ### [1.7.0] - 2026-06-04
 
 ### ✨ Mejoras

--- a/pjecz_casiopea_flask/blueprints/cit_citas/templates/cit_citas/detail.jinja2
+++ b/pjecz_casiopea_flask/blueprints/cit_citas/templates/cit_citas/detail.jinja2
@@ -8,9 +8,6 @@
 {% block topbar_actions %}
     {% call topbar.page_buttons('Cita ' + cit_cita.id | string) %}
         {{ topbar.button_previous('Citas', url_for('cit_citas.list_active')) }}
-        {% if cit_cita.estado == "PENDIENTE" %}
-            {{ topbar.button_primary('Marcar Asistencia', url_for('cit_citas.asistencia', cit_cita_id=cit_cita.id), icon='mdi mdi-check-circle') }}
-        {% endif %}
     {% endcall %}
 {% endblock %}
 

--- a/pjecz_casiopea_flask/templates/layouts/app.jinja2
+++ b/pjecz_casiopea_flask/templates/layouts/app.jinja2
@@ -57,7 +57,7 @@
                         {% endfor %}
                     {% endcall %}
                 </div>
-                <p id="version">versión: 1.7.0 (2025-06-04)</p>
+                <p id="version">versión: 1.7.1 (2025-06-08)</p>
             </div>
             <!-- Dashboard main -->
             <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pjecz-casiopea-flask"
-version = "1.7.0"
+version = "1.7.1"
 description = "Plataforma de administración del sistema de citas."
 readme = "README.md"
 requires-python = ">=3.14"


### PR DESCRIPTION
Se quitó la opción de "Marcar Asistencia" en el módulo `cit_citas`. Ya no era funcional, ahora se utiliza un código de barras. Genera confusión a los usuarios, que intentan escribir el código de barras en este campo, lo cual les marca un error.